### PR TITLE
Migrating from master/slave lingo

### DIFF
--- a/sbin/send-logfile.py
+++ b/sbin/send-logfile.py
@@ -99,9 +99,9 @@ class ESconnection:
         """
         aa=self.es.index(index='posts', doc_type='blog', id=1, body={
             'author': 'Santa Clause',
-            'blog': 'Slave Based Shippers of the North',
+            'blog': 'Subordinate Based Shippers of the North',
             'title': 'Using Celery for distributing gift dispatch',
-            'topics': ['slave labor', 'elves', 'python',
+            'topics': ['subordinate labor', 'elves', 'python',
                        'celery', 'antigravity reindeer'],
             'awesomeness': 0.2
         })


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.